### PR TITLE
Add pure local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ df['capitol'] = pd.DataFrame({'State': ['Colorado', 'Kansas', 'California', 'New
 
 ## Sketch currently uses `prompts.approx.dev` to help run with minimal setup
 
-In the future, we plan to update the prompts at this endpoint with our own custom foundation model, built to answer questions more accurately than GPT-3 can with its minimal data context. 
+You can also directly use a few pre-built hugging face models (right now `MPT-7B` and `StarCoder`), which will run entirely locally (once you download the model weights from HF).
+Do this by setting environment 3 variables:
+
+```python
+os.environ['LAMBDAPROMPT_BACKEND'] = 'StarCoder'
+os.environ['SKETCH_USE_REMOTE_LAMBDAPROMPT'] = 'False'
+os.environ['HF_ACCESS_TOKEN'] = 'your_hugging_face_token'
+```
 
 You can also directly call OpenAI directly (and not use our endpoint) by using your own API key. To do this, set 2 environment variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "datasketch>=1.5.8",
     "datasketches>=4.0.0",
     "ipython",
-    "lambdapromp>=0.5.2",
+    "lambdaprompt>=0.5.2",
     "packaging"
 ]
 urls = {homepage = "https://github.com/approximatelabs/sketch"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "datasketch>=1.5.8",
     "datasketches>=4.0.0",
     "ipython",
-    "lambdaprompt",
+    "lambdapromp>=0.5.2",
     "packaging"
 ]
 urls = {homepage = "https://github.com/approximatelabs/sketch"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 urls = {homepage = "https://github.com/approximatelabs/sketch"}
 dynamic = ["version"]
 
+[project.optional-dependencies]
+local = ["lambdaprompt[local]"]
+all = ["sketch[local]"]
 
 [tool.setuptools_scm]
 

--- a/sketch/pandas_extension.py
+++ b/sketch/pandas_extension.py
@@ -181,7 +181,7 @@ and run with your own open-ai key
     return text_to_copy
 
 
-howto_prompt = lambdaprompt.GPT3Prompt(
+howto_prompt = lambdaprompt.Completion(
     """
 For the pandas dataframe ({{ dfname }}) the user wants code to solve a problem.
 Summary statistics and descriptive data of dataframe [`{{ dfname }}`]:
@@ -234,7 +234,7 @@ def howto_from_parts(
     return code
 
 
-ask_prompt = lambdaprompt.GPT3Prompt(
+ask_prompt = lambdaprompt.Completion(
     """
 For the pandas dataframe ({{ dfname }}) the user wants an answer to a question about the data.
 Summary statistics and descriptive data of dataframe [`{{ dfname }}`]:
@@ -338,7 +338,7 @@ class SketchHelper:
             raise RuntimeError(
                 f"Too many rows for apply \n (SKETCH_ROW_OVERRIDE_LIMIT: {row_limit}, Actual: {len(self._obj)})"
             )
-        new_gpt3_prompt = lambdaprompt.GPT3Prompt(prompt_template_string)
+        new_gpt3_prompt = lambdaprompt.Completion(prompt_template_string)
         named_args = new_gpt3_prompt.get_named_args()
         known_args = set(self._obj.columns) | set(kwargs.keys())
         needed_args = set(named_args)


### PR DESCRIPTION
Pure local mode lets you use sketch without sending _any_ of your data over the network

Do this by setting 3 environment variables

1. `os.environ['SKETCH_USE_REMOTE_LAMBDAPROMPT'] = 'False'` (this turns off talking to us)
2. `os.environ['LAMBDAPROMPT_BACKEND'] = 'StarCoder'` (this sets StarCoder model as your backend (rather than relying on OpenAI) (if you want to be sure its set, check `lambdaprompt.backends.backends` and you can call `lambdaprompt.backends.set_backend('StarCoder')`
* `os.environ['HF_ACCESS_TOKEN'] = 'your_hugging_face_token'` (This is necessary for pulling star-coder, which has an OpenRAIL license --> IF you use `MPT` as your backend, you will not need the HF_ACCESS_TOKEN)

Notes!

The first install is pretty slow (downloading full weights). I timed it at ~9 minutes

Second runs (eg in a fresh kernel, where the weights are downloaded) still take ~2 minutes for the first request. 

But after, that, requests are pretty quick (on an A100 80GB) (and it should work on an A100 40 GB)



I think overall, the more I've been testing, I think StarCoder is actually weaker than OpenAI davinci, but it definitely still works

Here are some screenshots

<img width="768" alt="image" src="https://github.com/approximatelabs/sketch/assets/916073/d093acfe-a0ac-4426-ba17-6b1e198258eb">
(note it took 1.8s to complete this one)

<img width="684" alt="image" src="https://github.com/approximatelabs/sketch/assets/916073/5f95918f-a0fa-485c-90d6-c226f8fa267a">
(Note, this HTML list + description took 7.4 seconds)

<img width="915" alt="image" src="https://github.com/approximatelabs/sketch/assets/916073/44b6b305-96e1-4e94-bc0e-0dcb9b530174">

(when outputting a lot of code, grows to ~13 seconds)

Overall, these outputs are reasonable but I think when i pay close attention, they're not as good as GPT3 answers. But for a purely open, entirely local model, seems pretty great!